### PR TITLE
Bump node to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action runs cached `esy install` and `esy build` in the current directory
 ```yml
 - uses: actions/setup-node@v2
   with:
-    node-version: 14
+    node-version: 16
 - name: Install esy
   run: npm install -g esy
 - uses: esy/github-action@v1

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: JSON or opam file to be used
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: package


### PR DESCRIPTION
Currently when running esy/github-action I get following warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: esy/github-action@v1, actions/upload-artifact@v2, GabrielBB/xvfb-action@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR attempts to bump node to v16