### PR TITLE
Use a separate cache key for sources cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   cache-key:
     description: A cache key for esy.json/esy.lock.
     required: true
+  source-cache-key:
+    description: A cache key for retrieving esy sources cache.
+    required: true
   working-directory:
     description: Working directory for esy
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -87091,6 +87091,7 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 const esyPrefix = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("esy-prefix");
 const cacheKey = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("cache-key");
+const sourceCacheKey = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("source-cache-key");
 const manifestKey = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("manifest");
 function run(name, command, args) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -87112,7 +87113,7 @@ function main() {
             const platform = os__WEBPACK_IMPORTED_MODULE_4__.platform();
             const arch = os__WEBPACK_IMPORTED_MODULE_4__.arch();
             const installPath = ["~/.esy/source"];
-            const installKey = `source-${platform}-${arch}-${cacheKey}`;
+            const installKey = `source-${platform}-${arch}-${sourceCacheKey}`;
             _actions_core__WEBPACK_IMPORTED_MODULE_1__.startGroup("Restoring install cache");
             const installCacheKey = yield _actions_cache__WEBPACK_IMPORTED_MODULE_0__.restoreCache(installPath, installKey, []);
             if (installCacheKey) {

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import * as util from "util";
 
 const esyPrefix = core.getInput("esy-prefix");
 const cacheKey = core.getInput("cache-key");
+const sourceCacheKey = core.getInput("source-cache-key");
 const manifestKey = core.getInput("manifest");
 
 async function run(name: string, command: string, args: string[]) {
@@ -30,7 +31,7 @@ async function main() {
     const platform = os.platform();
     const arch = os.arch();
     const installPath = ["~/.esy/source"];
-    const installKey = `source-${platform}-${arch}-${cacheKey}`;
+    const installKey = `source-${platform}-${arch}-${sourceCacheKey}`;
     core.startGroup("Restoring install cache");
     const installCacheKey = await cache.restoreCache(
       installPath,


### PR DESCRIPTION
Its often desirable to be able to bust one cache store without hurting the other. 