### PR TITLE
Re-work how esy prefix is used to handle `EXDEV` errors.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,11 @@ const prepareNPMArtifactsMode = core.getInput("prepare-npm-artifacts-mode");
 const bundleNPMArtifactsMode = core.getInput("bundle-npm-artifacts-mode");
 const customPostInstallJS = core.getInput("postinstall-js");
 
+function appendEnvironmentFile(key: string, value: string) {
+  let filename = process.env.GITHUB_OUTPUT!;
+  fs.appendFileSync(filename, `${key}=${value}\n`);
+}
+
 async function run(name: string, command: string, args: string[]) {
   const PATH = process.env.PATH ? process.env.PATH : "";
   core.startGroup(name);
@@ -51,6 +56,10 @@ async function main() {
             ),
             ".esy"
           );
+    console.log("esy-prefix", esyPrefix);
+    const ghOutputEsyPrefixK = "ESY_PREFIX";
+    console.log(`Setting ${ghOutputEsyPrefixK} to`, esyPrefix);
+    appendEnvironmentFile(ghOutputEsyPrefixK, esyPrefix);
     const installPath = [`${esyPrefix}/source`];
     const installKey = `source-${platform}-${arch}-${sourceCacheKey}`;
     core.startGroup("Restoring install cache");

--- a/index.ts
+++ b/index.ts
@@ -19,8 +19,8 @@ const bundleNPMArtifactsMode = core.getInput("bundle-npm-artifacts-mode");
 const customPostInstallJS = core.getInput("postinstall-js");
 
 function appendEnvironmentFile(key: string, value: string) {
-  let filename = process.env.GITHUB_OUTPUT!;
-  fs.appendFileSync(filename, `${key}=${value}\n`);
+  fs.appendFileSync(process.env.GITHUB_OUTPUT!, `${key}=${value}\n`);
+  fs.appendFileSync(process.env.GITHUB_ENV!, `${key}=${value}\n`);
 }
 
 async function run(name: string, command: string, args: string[]) {

--- a/index.ts
+++ b/index.ts
@@ -47,9 +47,9 @@ async function main() {
               process.env.GITHUB_WORKSPACE ||
                 process.env.HOME ||
                 process.env.HOMEPATH ||
-                "~",
+                "~"
             ),
-            ".esy",
+            ".esy"
           );
     const installPath = [`${esyPrefix}/source`];
     const installKey = `source-${platform}-${arch}-${sourceCacheKey}`;
@@ -57,7 +57,7 @@ async function main() {
     const installCacheKey = await cache.restoreCache(
       installPath,
       installKey,
-      [],
+      []
     );
     if (installCacheKey) {
       console.log("Restored the install cache");
@@ -84,7 +84,7 @@ async function main() {
     const buildCacheKey = await cache.restoreCache(
       depsPath,
       buildKey,
-      restoreKeys,
+      restoreKeys
     );
     if (buildCacheKey) {
       console.log("Restored the build cache");
@@ -120,7 +120,7 @@ async function main() {
 async function uncompress(
   dest: string,
   tarFile: string,
-  strip?: number,
+  strip?: number
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     fs.createReadStream(tarFile)
@@ -128,7 +128,7 @@ async function uncompress(
         tar.x({
           strip: strip,
           C: dest, // alias for cwd:'some-dir', also ok
-        }),
+        })
       )
       .on("close", () => resolve())
       .on("error", reject);
@@ -147,7 +147,7 @@ async function prepareNPMArtifacts() {
   const statusCmd = manifestKey ? `esy ${manifestKey} status` : "esy status";
   try {
     const manifestFilePath = JSON.parse(
-      cp.execSync(statusCmd).toString(),
+      cp.execSync(statusCmd).toString()
     ).rootPackageConfigPath;
     const manifest = JSON.parse(fs.readFileSync(manifestFilePath).toString());
     if (manifest.esy.release) {
@@ -172,7 +172,7 @@ async function prepareNPMArtifacts() {
         // optional: how long to retain the artifact
         // if unspecified, defaults to repository/org retention settings (the limit of this value)
         retentionDays: 10,
-      },
+      }
     );
 
     console.log(`Created artifact with id: ${id} (bytes: ${size}`);
@@ -203,19 +203,19 @@ async function bundleNPMArtifacts() {
       });
       await uncompress(folderPath, path.join(folderPath, "npm-tarball.tgz"), 1);
       return folderName;
-    }),
+    })
   );
   const artifactFolders = artifactFoldersList.reduce(
     (acc: string[], folderName: string) => {
       acc.push(folderName);
       return acc;
     },
-    [],
+    []
   );
   const esyInstallReleaseJS = "esyInstallRelease.js";
   fs.cpSync(
     path.join(releaseFolder, artifactFoldersList[0], esyInstallReleaseJS),
-    path.join(releaseFolder, esyInstallReleaseJS),
+    path.join(releaseFolder, esyInstallReleaseJS)
   );
   console.log("Creating package.json");
   const possibleEsyJsonPath = path.join(workingDirectory, "esy.json");
@@ -229,21 +229,21 @@ async function bundleNPMArtifacts() {
     process.exit(1);
   }
   const mainPackageJson = JSON.parse(
-    fs.readFileSync(`${mainPackageJsonPath}`).toString(),
+    fs.readFileSync(`${mainPackageJsonPath}`).toString()
   );
   const bins = Array.isArray(mainPackageJson.esy.release.bin)
     ? mainPackageJson.esy.release.bin.reduce(
         (acc: any, curr: string) =>
           Object.assign({ [curr]: "bin/" + curr }, acc),
-        {},
+        {}
       )
     : Object.keys(mainPackageJson.esy.release.bin).reduce(
         (acc, currKey) =>
           Object.assign(
             { [currKey]: "bin/" + mainPackageJson.esy.release.bin[currKey] },
-            acc,
+            acc
           ),
-        {},
+        {}
       );
   const rewritePrefix =
     mainPackageJson.esy &&
@@ -276,7 +276,7 @@ async function bundleNPMArtifacts() {
       ].concat(artifactFolders),
     },
     null,
-    2,
+    2
   );
 
   fs.writeFileSync(path.join(releaseFolder, "package.json"), packageJson, {
@@ -287,7 +287,7 @@ async function bundleNPMArtifacts() {
     console.log("Copying LICENSE");
     fs.copyFileSync(
       path.join(workingDirectory, "LICENSE"),
-      path.join(releaseFolder, "LICENSE"),
+      path.join(releaseFolder, "LICENSE")
     );
   } catch (e) {
     console.warn("No LICENSE found");
@@ -297,7 +297,7 @@ async function bundleNPMArtifacts() {
     console.log("Copying README.md");
     fs.copyFileSync(
       path.join(workingDirectory, "README.md"),
-      path.join(releaseFolder, "README.md"),
+      path.join(releaseFolder, "README.md")
     );
   } catch {
     console.warn("No LICENSE found");
@@ -308,7 +308,7 @@ async function bundleNPMArtifacts() {
   console.log("Copying postinstall.js from", releasePostInstallJS);
   fs.copyFileSync(
     releasePostInstallJS,
-    path.join(releaseFolder, "postinstall.js"),
+    path.join(releaseFolder, "postinstall.js")
   );
 
   console.log("Creating placeholder files");
@@ -345,7 +345,7 @@ ECHO You need to have postinstall enabled`;
       // optional: how long to retain the artifact
       // if unspecified, defaults to repository/org retention settings (the limit of this value)
       retentionDays: 10,
-    },
+    }
   );
 
   core.endGroup();


### PR DESCRIPTION
With the newly introduced (still in beta) `node_modules` linker, the CI (as well as users) might run into `EXDEV` issues when esy hardlinks NPM dependencies from cache to a project path which is on a different drive. On Github Actions Windows runner, for instance, the `HOMEPATH` is usually on `C:/` and working directory on `D:/`.

To work around this, the action is better of placing the esy stores (cache) in the same drive that it has access too. With some trial-and-error, I learn, all paths under `D:/` is not necessarily writable. So, this PR computes esy prefix by simply traversing one level up in the current working directory path (where we have write accesss).

This however breaks user's assumptions - they'd expect this action to work just like esy does on local machines (i.e. place esy store at `C:/` or `$HOME/.esy`. This means, if they simply run esy commands (for instance, if they wish to export esy dependencies as a relocatable cache with `esy export-dependencies`), it would not work because the prefix path on the CI is different from default on.

To work around this, this action must expose the computed path with GITHUB_ENV or something which users can access as they write CI scripts.

There's a separate UX related issue wrt esy itself when it comes to handling the `EXDEV` problem. It's being tracked [here](https://github.com/esy/esy/issues/1606) - since this problem is not evident in all cases - only if the project opts into the `node_modules` linker for NPM projects. Perhaps this action could use esy to figure if this custom prefix solution is needed in the first place, in a future PR.

