### PR TITLE
Improvements and bug fixes

### DIFF
--- a/dist/release-postinstall.js
+++ b/dist/release-postinstall.js
@@ -102,11 +102,8 @@ function copyFileSync(sourcePath, destPath) {
   fs.chmodSync(destPath, 0755);
 }
 
-var copyPlatformBinaries = (platformPath) => {
-  var platformBuildPath = path.join(
-    __dirname,
-    "platform-esy-npm-release-" + platformPath
-  );
+var copyPlatformBinaries = (platformPath, foldersToCopy) => {
+  var platformBuildPath = path.join(__dirname, platformPath);
 
   let foldersToCopy, binariesToCopy;
 
@@ -114,13 +111,7 @@ var copyPlatformBinaries = (platformPath) => {
     return packageJson.bin[name];
   });
 
-  if (platformPath === "linux") {
-    fs.mkdirSync(path.join(__dirname, "lib"));
-    foldersToCopy = ["bin", "lib"];
-  } else {
-    foldersToCopy = ["bin", "_export"];
-    binariesToCopy = binariesToCopy.concat(["esyInstallRelease.js"]);
-  }
+  binariesToCopy = binariesToCopy.concat(["esyInstallRelease.js"]);
 
   foldersToCopy.forEach((folderPath) => {
     var sourcePath = path.join(platformBuildPath, folderPath);
@@ -166,18 +157,26 @@ switch (platform) {
       console.warn("error: x86 is currently not supported on Windows");
       process.exit(1);
     }
-
-    copyPlatformBinaries("windows-x64");
+    copyPlatformBinaries("platform-esy-npm-release-windows-x64", [
+      "bin",
+      "_export",
+    ]);
     require("./esyInstallRelease");
     break;
   case "linux":
-    copyPlatformBinaries(`${platform}-${platformArch}`);
+    copyPlatformBinaries(`platform-esy-npm-release-linux-${platformArch}`, [
+      "bin",
+      "_export",
+    ]);
     // Statically linked binaries dont need postinstall scripts
     // TODO add support for statically linked binaries
     require("./esyInstallRelease");
     break;
   case "darwin":
-    copyPlatformBinaries(`${platform}-${platformArch}`);
+    copyPlatformBinaries(`platform-esy-npm-release-darwin-${platformArch}`, [
+      "bin",
+      "_export",
+    ]);
     require("./esyInstallRelease");
     break;
   default:

--- a/index.ts
+++ b/index.ts
@@ -22,15 +22,7 @@ let esyPrefix = core.getInput("esy-prefix");
 esyPrefix =
   esyPrefix && esyPrefix !== ""
     ? esyPrefix
-    : path.join(
-        path.dirname(
-          process.env.GITHUB_WORKSPACE ||
-            process.env.HOME ||
-            process.env.HOMEPATH ||
-            "~"
-        ),
-        ".esy"
-      );
+    : path.join(path.resolve(".."), ".esy");
 console.log("esy-prefix", esyPrefix);
 const ghOutputEsyPrefixK = "ESY_PREFIX";
 console.log(`Setting ${ghOutputEsyPrefixK} to`, esyPrefix);

--- a/index.ts
+++ b/index.ts
@@ -219,14 +219,9 @@ async function main() {
 
     const depsPath = [path.join(esyPrefix, esy3!, "i")];
     const buildKey = `build-${platform}-${arch}-${cacheKey}`;
-    const restoreKeys = [`build-${platform}-${arch}-`, `build-`];
 
     core.startGroup("Restoring build cache");
-    const buildCacheKey = await cache.restoreCache(
-      depsPath,
-      buildKey,
-      restoreKeys
-    );
+    const buildCacheKey = await cache.restoreCache(depsPath, buildKey, []);
     if (buildCacheKey) {
       console.log("Restored the build cache");
     }

--- a/release-postinstall.js
+++ b/release-postinstall.js
@@ -102,11 +102,8 @@ function copyFileSync(sourcePath, destPath) {
   fs.chmodSync(destPath, 0755);
 }
 
-var copyPlatformBinaries = (platformPath) => {
-  var platformBuildPath = path.join(
-    __dirname,
-    "platform-esy-npm-release-" + platformPath
-  );
+var copyPlatformBinaries = (platformPath, foldersToCopy) => {
+  var platformBuildPath = path.join(__dirname, platformPath);
 
   let foldersToCopy, binariesToCopy;
 
@@ -114,13 +111,7 @@ var copyPlatformBinaries = (platformPath) => {
     return packageJson.bin[name];
   });
 
-  if (platformPath === "linux") {
-    fs.mkdirSync(path.join(__dirname, "lib"));
-    foldersToCopy = ["bin", "lib"];
-  } else {
-    foldersToCopy = ["bin", "_export"];
-    binariesToCopy = binariesToCopy.concat(["esyInstallRelease.js"]);
-  }
+  binariesToCopy = binariesToCopy.concat(["esyInstallRelease.js"]);
 
   foldersToCopy.forEach((folderPath) => {
     var sourcePath = path.join(platformBuildPath, folderPath);
@@ -166,18 +157,26 @@ switch (platform) {
       console.warn("error: x86 is currently not supported on Windows");
       process.exit(1);
     }
-
-    copyPlatformBinaries("windows-x64");
+    copyPlatformBinaries("platform-esy-npm-release-windows-x64", [
+      "bin",
+      "_export",
+    ]);
     require("./esyInstallRelease");
     break;
   case "linux":
-    copyPlatformBinaries(`${platform}-${platformArch}`);
+    copyPlatformBinaries(`platform-esy-npm-release-linux-${platformArch}`, [
+      "bin",
+      "_export",
+    ]);
     // Statically linked binaries dont need postinstall scripts
     // TODO add support for statically linked binaries
     require("./esyInstallRelease");
     break;
   case "darwin":
-    copyPlatformBinaries(`${platform}-${platformArch}`);
+    copyPlatformBinaries(`platform-esy-npm-release-darwin-${platformArch}`, [
+      "bin",
+      "_export",
+    ]);
     require("./esyInstallRelease");
     break;
   default:


### PR DESCRIPTION
Behaviour change: no more restoreKey lookups. 
Use `path.resolve` to avoid relative paths on Windows
Refactor postinstall.js 