### PR TITLE
Fixes for projects that use custom working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Path where esy can setup the cache. Default: `$HOME/.esy`
 #### `working-directory`
 
 Working directory of the project. Useful for projects that place esy project
-under a folder.
+under a folder. It's converted into an absolute path, if it already isn't.
 
 Default: Action workspace root.
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: A cache key for retrieving esy sources cache.
     required: true
   working-directory:
-    description: Working directory for esy
+    description: Working directory for esy. It's converted into an absolute path, if it already isn't
     required: false
   esy-prefix:
     description: Prefix of esy folder

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,9 @@ inputs:
     description: A cache key for retrieving esy sources cache.
     required: true
   working-directory:
-    description: Working directory for esy. It's converted into an absolute path, if it already isn't
+    description:
+      Working directory for esy. It's converted into an absolute path, if it
+      already isn't
     required: false
   esy-prefix:
     description: Prefix of esy folder

--- a/index.ts
+++ b/index.ts
@@ -288,7 +288,7 @@ async function prepareNPMArtifacts() {
   const statusCmd = manifestKey ? `esy ${manifestKey} status` : "esy status";
   try {
     const manifestFilePath = JSON.parse(
-      cp.execSync(statusCmd).toString()
+      cp.execSync(statusCmd, { cwd: workingDirectory }).toString()
     ).rootPackageConfigPath;
     const manifest = JSON.parse(fs.readFileSync(manifestFilePath).toString());
     if (manifest.esy?.release) {

--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,10 @@ workingDirectory = path.isAbsolute(workingDirectory)
 async function run(name: string, command: string, args: string[]) {
   const PATH = process.env.PATH ? process.env.PATH : "";
   core.startGroup(name);
-  await exec(command, args, { env: { ...process.env, PATH } });
+  await exec(command, args, {
+    env: { ...process.env, PATH },
+    cwd: workingDirectory,
+  });
   core.endGroup();
 }
 

--- a/index.ts
+++ b/index.ts
@@ -291,7 +291,7 @@ async function prepareNPMArtifacts() {
       cp.execSync(statusCmd).toString()
     ).rootPackageConfigPath;
     const manifest = JSON.parse(fs.readFileSync(manifestFilePath).toString());
-    if (manifest.esy.release) {
+    if (manifest.esy?.release) {
       await runEsyCommand("Running esy npm-release", ["npm-release"]);
     }
     let tarFile = `npm-tarball.tgz`;

--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,12 @@ function computeChecksum(filePath: string, algo: string) {
 const platform = os.platform();
 const arch = os.arch();
 async function main() {
-  const workingDirectory = core.getInput("working-directory") || process.cwd();
+  let workingDirectory = core.getInput("working-directory") || process.cwd();
+  workingDirectory = path.isAbsolute(workingDirectory)
+    ? workingDirectory
+    : path.join(process.cwd(), workingDirectory);
+  // Otherwise, when we change directories and then back (workingDirectory -> /tmp -> workingDirectory)
+  // chdir() would try to enter a path relative to that path
   try {
     if (setupEsy) {
       let tarballUrl, checksum, esyPackageVersion, esyPackageName;

--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,10 @@ if (partsSeparatedBtAT.length > 1 && partsSeparatedBtAT[0] !== "") {
   );
   process.exit(-1);
 }
+let workingDirectory = core.getInput("working-directory") || process.cwd();
+workingDirectory = path.isAbsolute(workingDirectory)
+  ? workingDirectory
+  : path.join(process.cwd(), workingDirectory);
 
 async function run(name: string, command: string, args: string[]) {
   const PATH = process.env.PATH ? process.env.PATH : "";
@@ -128,10 +132,6 @@ function computeChecksum(filePath: string, algo: string) {
 const platform = os.platform();
 const arch = os.arch();
 async function main() {
-  let workingDirectory = core.getInput("working-directory") || process.cwd();
-  workingDirectory = path.isAbsolute(workingDirectory)
-    ? workingDirectory
-    : path.join(process.cwd(), workingDirectory);
   // Otherwise, when we change directories and then back (workingDirectory -> /tmp -> workingDirectory)
   // chdir() would try to enter a path relative to that path
   try {
@@ -295,7 +295,7 @@ async function prepareNPMArtifacts() {
       await runEsyCommand("Running esy npm-release", ["npm-release"]);
     }
     let tarFile = `npm-tarball.tgz`;
-    await compress("_release", tarFile);
+    await compress(path.join(workingDirectory, "_release"), tarFile);
 
     const artifactName = `esy-npm-release-${platform}-${arch}`;
     console.log("Artifact name: ", artifactName);
@@ -327,7 +327,6 @@ async function prepareNPMArtifacts() {
 }
 
 async function bundleNPMArtifacts() {
-  const workingDirectory = core.getInput("working-directory") || process.cwd();
   fs.statSync(workingDirectory);
   process.chdir(workingDirectory);
   const releaseFolder = path.join(workingDirectory, "_npm-release");


### PR DESCRIPTION
* Makes working-directory absolute if it wasn't

* Make manifest.esy property optional

* Fixes working directory while npm-release

* Guard the prepare-npm-artifacts mode against missing esy.release config

* Fixes workingDirectory of esy status command

* Fixes workingDirectory of esy npm-release command

* Build on Ubuntu