### PR TITLE
Pick store version as per esy CLI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@actions/exec": "1.x",
     "@actions/github": "^6.0.0",
     "@actions/tool-cache": "^2.0.1",
+    "@types/semver": "^7.7.0",
+    "semver": "^7.7.2",
     "tar": "^7.1.0",
     "typescript": "5.x",
     "validate-npm-package-name": "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,6 +508,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/semver@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.0.tgz#64c441bdae033b378b6eef7d0c3d77c329b9378e"
+  integrity sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==
+
 "@types/tar@^6.1.13":
   version "6.1.13"
   resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.13.tgz#9b5801c02175344101b4b91086ab2bbc8e93a9b6"
@@ -1189,6 +1194,11 @@ semver@^6.1.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.7.2:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
With the recent release of esy change store version to 4 (from 3), this action needs an update to reflect the new path. To preserve backward compatibility, we use the new version only if CLI is greater than 0.9.0