### PR TITLE
Fix compiler version detection in bundle job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,27 @@ inputs:
   manifest:
     description: JSON or opam file to be used
     required: false
+  ocaml-compiler-version:
+    description:
+      Version of ocaml compiler (in semver. Eg. 5.1.0 or 4.10.1000) Optional,
+      but mandatory if prepare-npm-artifacts-mode and bundle-npm-artifacts-mode
+      is used. This is because, these version strings affect the relocatability
+      logic while both preparation mode, and while postinstall scripts are
+      generated during bundling mode.
+    required: false
+  ocaml-static-compiler-version:
+    description:
+      Version of static ocaml compiler (in semver. Eg. 5.1.0-musl.static.flambda
+      or 4.10.1000-musl.static.flambda). Optional, but mandatory if
+      prepare-npm-artifacts-mode and bundle-npm-artifacts-mode is used. This is
+      because, these version strings affect the relocatability logic while both
+      preparation mode, and while postinstall scripts are generated during
+      bundling mode.
+    required: false
   prepare-npm-artifacts-mode:
     description:
       Runs a steps that prepare artifacts for release the app to NPM. These
-      artifacts are later used by, `bundle-npm-tarball-mode`
+      artifacts are later used by, `bundle-npm-tarball-mode`.
     required: false
   bundle-npm-artifacts-mode:
     description: Runs a steps that bundle artifacts for release the app to NPM.

--- a/index.ts
+++ b/index.ts
@@ -54,9 +54,14 @@ workingDirectory = path.isAbsolute(workingDirectory)
   ? workingDirectory
   : path.join(process.cwd(), workingDirectory);
 
+function cli(cmd: string) {
+  console.log(`cli: ${cmd}`);
+  return cp.execSync(cmd).toString().trim();
+}
+
 function getEsyCLIVersion() {
   const cmd = "esy --version";
-  return cp.execSync(cmd).toString().trim();
+  return cli(cmd);
 }
 
 function getEsyStoreVersion() {
@@ -106,7 +111,7 @@ function getCompilerVersion(sandbox?: string) {
   const ocamlcVersionCmd = sandbox
     ? `esy ${sandbox} ocamlc --version`
     : "esy ocamlc --version";
-  return cp.execSync(ocamlcVersionCmd).toString();
+  return cli(ocamlcVersionCmd);
 }
 
 async function run(name: string, command: string, args: string[]) {
@@ -468,16 +473,12 @@ async function bundleNPMArtifacts() {
     mainPackageJson.esy.release &&
     mainPackageJson.esy.release.rewritePrefix;
 
-  function exec(cmd: string) {
-    console.log(`exec: ${cmd}`);
-    return cp.execSync(cmd).toString().trim();
-  }
-  const version = exec("git describe --tags --always");
-
   const compilerVersion = getCompilerVersion();
   console.log("Found compiler version", compilerVersion);
   const staticCompilerVersion = getCompilerVersion("static.esy");
   console.log("Found static compiler version", staticCompilerVersion);
+
+  const version = cli("git describe --tags --always");
 
   const packageJson = JSON.stringify(
     {


### PR DESCRIPTION
We need the compiler version to calculate the prefix path during preparation of NPM tarballs for different platforms and bundling into one tarball later. In the former stage, we need to rewrite prefixes and in the latter, to generate the postinstall.js script which would correctly rewrite the prefix again on the target machine.